### PR TITLE
Use protobuf.Root instead of specific services

### DIFF
--- a/protocol/test-package.proto
+++ b/protocol/test-package.proto
@@ -1,0 +1,23 @@
+syntax = "proto2";
+
+package testNamespaceWithSameMethods;
+
+message Empty {}
+
+service TestService {
+    rpc Echo (TextMessage) returns (TextMessage) {}
+    rpc Upper (TextMessage) returns (TextMessage) {}
+    rpc NotImplemented (EmptyMessage) returns (EmptyMessage) {}
+}
+
+message EmptyMessage {}
+
+message TextMessage {
+    required string text = 1;
+}
+
+message EventRequest {
+    required string name = 1;
+    required uint32 delay = 2;
+}
+

--- a/protocol/test-package.proto
+++ b/protocol/test-package.proto
@@ -2,22 +2,11 @@ syntax = "proto2";
 
 package testNamespaceWithSameMethods;
 
-message Empty {}
-
 service TestService {
-    rpc Echo (TextMessage) returns (TextMessage) {}
     rpc Upper (TextMessage) returns (TextMessage) {}
-    rpc NotImplemented (EmptyMessage) returns (EmptyMessage) {}
+    rpc lower (TextMessage) returns (TextMessage) {}
 }
-
-message EmptyMessage {}
 
 message TextMessage {
     required string text = 1;
 }
-
-message EventRequest {
-    required string name = 1;
-    required uint32 delay = 2;
-}
-

--- a/protocol/test.proto
+++ b/protocol/test.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+syntax = "proto2";
 
 message Empty {}
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -118,7 +118,7 @@ export class Client extends EventEmitter implements IClientEvents {
     /**
      * Protobuf rpc service instances.
      */
-    public readonly services: {[name: string]: protobuf.rpc.Service} = {}
+    public readonly services: {[name: string]: any} = {}
 
     public readonly root: protobuf.Root
 
@@ -148,7 +148,8 @@ export class Client extends EventEmitter implements IClientEvents {
         const services = lookupServices(this.root)
         services.forEach((serviceName) => {
             const service = this.root.lookupService(serviceName)
-            this.services[serviceName] = service.create(this.rpcImpl)
+            const rpcService: protobuf.rpc.Service = service.create(this.rpcImpl)
+            this.services[serviceName] = rpcService
         })
 
         this.eventTypes = options.eventTypes || {}
@@ -161,7 +162,7 @@ export class Client extends EventEmitter implements IClientEvents {
         }
     }
 
-    public service(serviceName: string): protobuf.rpc.Service {
+    public service<T extends protobuf.rpc.Service>(serviceName: string): T {
         return this.services[serviceName]
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,7 +34,7 @@
  */
 
 import {EventEmitter} from 'events'
-import {ReflectionObject} from 'protobufjs'
+import {ReflectionObject, Service, Namespace} from 'protobufjs'
 
 /**
  * Return a promise that will resove when a specific event is emitted.
@@ -63,4 +63,27 @@ export function getFullName(obj: ReflectionObject, names: string[] = []): string
     }
 
     return names.join('.')
+}
+
+/**
+ * Get all protobuf.Service in a protobuf.ReflectionObject.
+ * returns with an array of fully namespaced services.
+ *
+ * Example return:
+ * ['packageName.serviceName.methodName', 'differentPackageName.serviceName.methodName']
+ */
+export function lookupServices(obj: ReflectionObject): string[] {
+    const services: string[] = []
+
+    if (obj instanceof Service) {
+        services.push(getFullName(obj))
+    }
+
+    if (obj instanceof Namespace) {
+        obj.nestedArray.forEach((nestedObject: ReflectionObject) => {
+            services.push(...lookupServices(nestedObject))
+        })
+    }
+
+    return services
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,12 +73,11 @@ export function getFullName(obj: ReflectionObject, names: string[] = []): string
  * ['packageName.serviceName.methodName', 'differentPackageName.serviceName.methodName']
  */
 export function lookupServices(obj: Namespace | Service): string[] {
-    const services: string[] = []
-
     if (obj instanceof Service) {
-        services.push(getFullName(obj))
-        return services
+        return [getFullName(obj)]
     }
+
+    const services: string[] = []
 
     obj.nestedArray.forEach((nestedObject: Namespace) => {
         services.push(...lookupServices(nestedObject))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,14 @@ export function waitForEvent<T>(emitter: EventEmitter, eventName: string|symbol)
     })
 }
 
+/**
+ * Resolve full name of protobuf objects.
+ * This helps to distinguish services or methods with the same name but in different packages/namespaces.
+ *
+ * Example returns:
+ * 'packageName.serviceName.methodName'
+ * 'differentPackageName.serviceName.methodName'
+ */
 export function getFullName(obj: ReflectionObject, names: string[] = []): string {
     if (obj.name) {
         names.unshift(obj.name)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,7 +34,7 @@
  */
 
 import {EventEmitter} from 'events'
-import {ReflectionObject, Service, Namespace} from 'protobufjs'
+import {Namespace, ReflectionObject, Service} from 'protobufjs'
 
 /**
  * Return a promise that will resove when a specific event is emitted.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,18 +72,17 @@ export function getFullName(obj: ReflectionObject, names: string[] = []): string
  * Example return:
  * ['packageName.serviceName.methodName', 'differentPackageName.serviceName.methodName']
  */
-export function lookupServices(obj: ReflectionObject): string[] {
+export function lookupServices(obj: Namespace | Service): string[] {
     const services: string[] = []
 
     if (obj instanceof Service) {
         services.push(getFullName(obj))
+        return services
     }
 
-    if (obj instanceof Namespace) {
-        obj.nestedArray.forEach((nestedObject: ReflectionObject) => {
-            services.push(...lookupServices(nestedObject))
-        })
-    }
+    obj.nestedArray.forEach((nestedObject: Namespace) => {
+        services.push(...lookupServices(nestedObject))
+    })
 
     return services
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,6 +34,7 @@
  */
 
 import {EventEmitter} from 'events'
+import {ReflectionObject} from 'protobufjs'
 
 /**
  * Return a promise that will resove when a specific event is emitted.
@@ -42,4 +43,16 @@ export function waitForEvent<T>(emitter: EventEmitter, eventName: string|symbol)
     return new Promise((resolve, reject) => {
         emitter.once(eventName, resolve)
     })
+}
+
+export function getFullName(obj: ReflectionObject, names: string[] = []): string {
+    if (obj.name) {
+        names.unshift(obj.name)
+    }
+
+    if (obj.parent) {
+        return getFullName(obj.parent, names)
+    }
+
+    return names.join('.')
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -144,8 +144,7 @@ describe('rpc', () => {
         assert.equal(response.text, 'lower: hello world')
     })
 
-    it('should run without @ts-ignore if defined the type...', async function() {
-        // @ts-ignore
+    it('should run without @ts-ignore if the type is specified...', async function() {
         const service: testNamespaceWithSameMethods.TestService = client.service('testNamespaceWithSameMethods.TestService')
         const response = await service.lower({text: 'Hello World'})
         assert.equal(response.text, 'lower: hello world')


### PR DESCRIPTION

## Summary

> WARNING: this PR is not backwards compatible! Merging this should result in a major version change. E.g.: `2.0.0`

Use protobuf.Root object to describe every service on the server and the client.
Its more flexible and supports the usage of multiple services with the same name but in different packages. 

Use case example: https://github.com/jnordberg/wsrpc/issues/7

## Changes

Server:
- `constructor()` expects `protobuf.Root` as first parameter
- `implement()` changes:
  - string parameters are case sensitive now!
  - if you pass in a string it should to contain the full namespace of the method

Client:
- `constructor()` expects `protobuf.Root` as second parameter
- `client.service` was replaced with `client.service('packageName.serviceName')`

Tests:
- added new tests for new helper functions
- added new tests for namespaced services
- added new tests for case sensitive methods 
- extended protobuf.Root with other proto file